### PR TITLE
Add Roda#register

### DIFF
--- a/lib/roda/plugins/container.rb
+++ b/lib/roda/plugins/container.rb
@@ -106,6 +106,10 @@ class Roda
           Thread.current[:__container__] = self.class.send(:container).dup
           super
         end
+        
+        def register(*args, &block)
+          self.class.instance.register(*args, &block)
+        end
       end
     end
 

--- a/spec/integration/roda/plugins/container_spec.rb
+++ b/spec/integration/roda/plugins/container_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'container plugin' do
   context 'registering with "instance"' do
     it 'is threadsafe' do
       Test::Application.route do |r|
-        Test::Application.instance.register(:app, self, call: false)
+        register(:app, self, call: false)
 
         r.on 'concurrency' do
           r.on 'one' do


### PR DESCRIPTION
Adds a Roda#register method so that you can call register from within the route block rather than having to call Roda.instance.register
